### PR TITLE
Create 6 test cases for mytimsheets

### DIFF
--- a/pages/Employee_Management.ts
+++ b/pages/Employee_Management.ts
@@ -1,10 +1,7 @@
 import { Page, Locator, expect, BrowserContext } from '@playwright/test'
 import { BasePage } from './Basepage'
 import { Loader } from '../components/loaders'
-import fs from "fs";
 import { AssetHelper } from '../utils/AssetHelpers'
-
-
 
 
 export class Employee_Management extends BasePage {

--- a/pages/MyTimesheets.ts
+++ b/pages/MyTimesheets.ts
@@ -1,11 +1,20 @@
 import { expect, Locator, Page } from "@playwright/test";
 import { BasePage } from "./Basepage";
 
+type DailyEntryDropdown = "category" | "minutes" | "status";
+
 export class MyTimesheets extends BasePage {
-  readonly header: Locator;
-  readonly dailyTimeEntrySection: Locator;
-  readonly previousDayButton: Locator;
-  readonly nextDayButton: Locator;
+  private readonly header: Locator;
+  private readonly dailyTimeEntrySection: Locator;
+  private readonly previousDayButton: Locator;
+  private readonly nextDayButton: Locator;
+  private readonly projectDropdown: Locator;
+  private readonly categoryDropdown: Locator;
+  private readonly taskDescriptionTextArea: Locator;
+  private readonly hoursInput: Locator;
+  private readonly minutesDropdown: Locator;
+  private readonly statusDropdown: Locator;
+  private readonly visibleDropdownOptions: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -22,8 +31,36 @@ export class MyTimesheets extends BasePage {
       .first();
     this.previousDayButton = page.getByRole("button", { name: "Previous day" });
     this.nextDayButton = page.getByRole("button", { name: "Next day" });
+    this.projectDropdown = page.locator(
+      "#timesheet-add-entry-form-project-trigger"
+    );
+    this.categoryDropdown = page.locator(
+      "#timesheet-add-entry-form-category-trigger"
+    );
+    this.taskDescriptionTextArea = page.locator(
+      "#timesheet-add-entry-form-description"
+    );
+    this.hoursInput = page.locator("#timesheet-add-entry-form-hours");
+    this.minutesDropdown = page.locator(
+      "#timesheet-add-entry-form-minutes-trigger"
+    );
+    this.statusDropdown = page.locator(
+      "#timesheet-add-entry-form-status-trigger"
+    );
+    this.visibleDropdownOptions = page.locator(
+      [
+        "[role='option']:visible",
+        "[role='listbox']:visible [role='option']",
+        "[role='listbox']:visible li",
+        "[role='listbox']:visible div",
+        "[id*='listbox']:visible [role='option']",
+        "[id*='listbox']:visible li",
+        "[id*='listbox']:visible div",
+      ].join(", ")
+    );
   }
 
+  // Page load and date navigation
   async waitForMyTimesheetsPage(): Promise<void> {
     await this.waitforLoaderToDisappear();
     await expect(this.header).toHaveText("My Timesheets");
@@ -55,6 +92,99 @@ export class MyTimesheets extends BasePage {
     await this.nextDayButton.waitFor({ state: "visible" });
     await this.nextDayButton.click();
     await this.waitforLoaderToDisappear();
+  }
+
+  // Daily Time Entry form
+  async verifyProjectDropdownHasAvailableProjects(): Promise<void> {
+    await this.openDropdown(this.projectDropdown);
+    await expect(this.visibleDropdownOptions.first()).toBeVisible();
+    expect(await this.visibleDropdownOptions.count()).toBeGreaterThan(0);
+  }
+
+  async selectFirstAvailableProject(): Promise<void> {
+    await this.openDropdownIfClosed(this.projectDropdown);
+    const firstProject = this.visibleDropdownOptions.first();
+    const projectName = (await firstProject.innerText()).trim();
+
+    await firstProject.click();
+    await expect(this.projectDropdown).toContainText(projectName);
+  }
+
+  async selectCategory(categoryName: string): Promise<void> {
+    await this.selectDropdownOption("category", categoryName);
+  }
+
+  async fillTaskDescription(description: string): Promise<void> {
+    await this.taskDescriptionTextArea.click();
+    await this.taskDescriptionTextArea.fill(description);
+  }
+
+  async verifyTaskDescription(description: string): Promise<void> {
+    await expect(this.taskDescriptionTextArea).toHaveValue(description);
+  }
+
+  async fillHours(hours: string): Promise<void> {
+    await this.hoursInput.click();
+    await this.hoursInput.fill(hours);
+  }
+
+  async verifyHours(hours: string): Promise<void> {
+    await expect(this.hoursInput).toHaveValue(hours);
+  }
+
+  async selectMinutes(minutes: string): Promise<void> {
+    await this.selectDropdownOption("minutes", minutes);
+  }
+
+  async selectStatus(status: string): Promise<void> {
+    await this.selectDropdownOption("status", status);
+  }
+
+  async verifyDropdownSelectedValue(
+    dropdown: DailyEntryDropdown,
+    value: string
+  ): Promise<void> {
+    await expect(this.getDropdownLocator(dropdown)).toContainText(value);
+  }
+
+  private async selectDropdownOption(
+    dropdown: DailyEntryDropdown,
+    optionText: string
+  ): Promise<void> {
+    const dropdownLocator = this.getDropdownLocator(dropdown);
+
+    await this.openDropdown(dropdownLocator);
+    await this.visibleDropdownOptions
+      .getByText(optionText, { exact: true })
+      .click();
+    await expect(dropdownLocator).toContainText(optionText);
+  }
+
+  private async openDropdown(dropdown: Locator): Promise<void> {
+    await dropdown.waitFor({ state: "visible" });
+    await dropdown.click();
+    await expect(dropdown).toHaveAttribute("aria-expanded", "true");
+    await expect(this.visibleDropdownOptions.first()).toBeVisible();
+  }
+
+  private async openDropdownIfClosed(dropdown: Locator): Promise<void> {
+    const isExpanded = await dropdown
+      .getAttribute("aria-expanded")
+      .then((value) => value === "true");
+
+    if (!isExpanded) {
+      await this.openDropdown(dropdown);
+    }
+  }
+
+  private getDropdownLocator(dropdown: DailyEntryDropdown): Locator {
+    const dropdowns: Record<DailyEntryDropdown, Locator> = {
+      category: this.categoryDropdown,
+      minutes: this.minutesDropdown,
+      status: this.statusDropdown,
+    };
+
+    return dropdowns[dropdown];
   }
 
   private formatDailyTimeEntryDate(date: Date): string {

--- a/pages/MyTimesheets.ts
+++ b/pages/MyTimesheets.ts
@@ -1,0 +1,68 @@
+import { expect, Locator, Page } from "@playwright/test";
+import { BasePage } from "./Basepage";
+
+export class MyTimesheets extends BasePage {
+  readonly header: Locator;
+  readonly dailyTimeEntrySection: Locator;
+  readonly previousDayButton: Locator;
+  readonly nextDayButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+
+    this.header = page.locator("h2.heading-lg");
+    this.dailyTimeEntrySection = page
+      .locator("[class*='timesheet-entry-card']")
+      .filter({ hasText: "Daily Time Entry" })
+      .or(
+        page
+          .locator("section, article, div")
+          .filter({ hasText: "Daily Time Entry" })
+      )
+      .first();
+    this.previousDayButton = page.getByRole("button", { name: "Previous day" });
+    this.nextDayButton = page.getByRole("button", { name: "Next day" });
+  }
+
+  async waitForMyTimesheetsPage(): Promise<void> {
+    await this.waitforLoaderToDisappear();
+    await expect(this.header).toHaveText("My Timesheets");
+  }
+
+  async verifyDailyTimeEntryDate(expectedDate: Date = new Date()): Promise<void> {
+    await this.waitforLoaderToDisappear();
+    await expect(this.dailyTimeEntrySection).toBeVisible();
+
+    const sectionText = await this.dailyTimeEntrySection.innerText();
+    const expectedDateText = this.formatDailyTimeEntryDate(expectedDate);
+
+    expect(sectionText).toContain(expectedDateText);
+  }
+
+  async getDailyTimeEntryText(): Promise<string> {
+    await this.waitforLoaderToDisappear();
+    await expect(this.dailyTimeEntrySection).toBeVisible();
+    return (await this.dailyTimeEntrySection.innerText()).trim();
+  }
+
+  async clickPreviousDay(): Promise<void> {
+    await this.previousDayButton.waitFor({ state: "visible" });
+    await this.previousDayButton.click();
+    await this.waitforLoaderToDisappear();
+  }
+
+  async clickNextDay(): Promise<void> {
+    await this.nextDayButton.waitFor({ state: "visible" });
+    await this.nextDayButton.click();
+    await this.waitforLoaderToDisappear();
+  }
+
+  private formatDailyTimeEntryDate(date: Date): string {
+    const weekday = date.toLocaleString("en-US", { weekday: "short" });
+    const shortMonth = date.toLocaleString("en-US", { month: "short" });
+    const day = date.getDate();
+    const year = date.getFullYear();
+
+    return `${weekday}, ${shortMonth} ${day}, ${year}`;
+  }
+}

--- a/pages/MyTimesheets.ts
+++ b/pages/MyTimesheets.ts
@@ -14,6 +14,9 @@ export class MyTimesheets extends BasePage {
   private readonly hoursInput: Locator;
   private readonly minutesDropdown: Locator;
   private readonly statusDropdown: Locator;
+  private readonly addEntryButton: Locator;
+  private readonly submitTimesheetButton: Locator;
+  private readonly timesheetEntriesTable: Locator;
   private readonly visibleDropdownOptions: Locator;
 
   constructor(page: Page) {
@@ -47,6 +50,15 @@ export class MyTimesheets extends BasePage {
     this.statusDropdown = page.locator(
       "#timesheet-add-entry-form-status-trigger"
     );
+    this.addEntryButton = page.locator(
+      'button[class*="add-new-entry-card_button"]'
+    );
+    this.submitTimesheetButton = page.locator(
+      'button[class*="button_accent"]'
+    ).filter({ hasText: "Submit Timesheet for Approval" });
+    this.timesheetEntriesTable = page.getByRole("table", {
+      name: "Timesheet entries",
+    });
     this.visibleDropdownOptions = page.locator(
       [
         "[role='option']:visible",
@@ -138,6 +150,27 @@ export class MyTimesheets extends BasePage {
 
   async selectStatus(status: string): Promise<void> {
     await this.selectDropdownOption("status", status);
+  }
+
+  async clickAddEntry(): Promise<void> {
+    await expect(this.addEntryButton).toBeVisible();
+    await this.addEntryButton.click();
+    await this.waitforLoaderToDisappear();
+  }
+
+  async verifyTimesheetEntryAdded(taskDescription: string): Promise<void> {
+    const entryRow = this.timesheetEntriesTable
+      .getByRole("row")
+      .filter({ hasText: taskDescription });
+
+    await expect(entryRow).toBeVisible({ timeout: 4000 });
+  }
+
+  async clickSubmitTimesheetForApproval(): Promise<void> {
+    await expect(this.submitTimesheetButton).toBeVisible();
+    await this.submitTimesheetButton.click();
+    await this.waitforLoaderToDisappear();
+    await this.page.waitForTimeout(5000);
   }
 
   async verifyDropdownSelectedValue(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,8 +31,8 @@ export default defineConfig({
   // ],
   fullyParallel: true,
   retries: process.env.CI ? 1 : 0,
-  // workers: process.env.CI ? 1 : undefined,
-  workers: 4,
+  // Override from CLI when needed, for example: --workers=4
+  workers: 1,
   reporter: [["html", { open: 'never' }], ['line'], ["allure-playwright"], ["./my-reporter.ts"], ['json', { outputFile: 'playwright-report/results.json' }]],
   // reporter: [['list'], ['junit', { outputFile: 'results.xml' }]],
 

--- a/tests/TimesheetManagement/myTimesheet.spec.ts
+++ b/tests/TimesheetManagement/myTimesheet.spec.ts
@@ -63,7 +63,9 @@ test.describe("My Timesheets page", () => {
     await myTimesheets.verifyDailyTimeEntryDate();
   });
 
-  test("HRIMS_MTS_7, HRIMS_MTS_11, HRIMS_MTS_20, HRIMS_MTS_21, HRIMS_MTS_22, HRIMS_MTS_24, Verify user can fill Daily Time Entry form fields @smoke @reg", async () => {
+  test("HRMIS_MTS_07, HRIMS_MTS_7, HRIMS_MTS_11, HRIMS_MTS_20, HRIMS_MTS_21, HRIMS_MTS_22, HRIMS_MTS_24, HRMIS_MTS_25, Verify user can fill Daily Time Entry form fields and add entry @smoke @reg", async () => {
+    const taskDescription = "testing";
+
     await test.step("Verify Select Project dropdown shows available projects", async () => {
       await myTimesheets.verifyProjectDropdownHasAvailableProjects();
     });
@@ -78,8 +80,8 @@ test.describe("My Timesheets page", () => {
     });
 
     await test.step("Enter task description", async () => {
-      await myTimesheets.fillTaskDescription("testing");
-      await myTimesheets.verifyTaskDescription("testing");
+      await myTimesheets.fillTaskDescription(taskDescription);
+      await myTimesheets.verifyTaskDescription(taskDescription);
     });
 
     await test.step("Enter hours worked", async () => {
@@ -96,5 +98,17 @@ test.describe("My Timesheets page", () => {
       await myTimesheets.selectStatus("In Progress");
       await myTimesheets.verifyDropdownSelectedValue("status", "In Progress");
     });
+
+    await test.step("Click Add Entry button", async () => {
+      await myTimesheets.clickAddEntry();
+    });
+
+    await test.step("Verify timesheet entry was added", async () => {
+      await myTimesheets.verifyTimesheetEntryAdded(taskDescription);
+    });
+
+    // await test.step("Submit timesheet for approval", async () => {
+    //   await myTimesheets.clickSubmitTimesheetForApproval();
+    // });
   });
 });

--- a/tests/TimesheetManagement/myTimesheet.spec.ts
+++ b/tests/TimesheetManagement/myTimesheet.spec.ts
@@ -62,4 +62,39 @@ test.describe("My Timesheets page", () => {
     await expect.poll(() => myTimesheets.getDailyTimeEntryText()).toBe(currentDayText);
     await myTimesheets.verifyDailyTimeEntryDate();
   });
+
+  test("HRIMS_MTS_7, HRIMS_MTS_11, HRIMS_MTS_20, HRIMS_MTS_21, HRIMS_MTS_22, HRIMS_MTS_24, Verify user can fill Daily Time Entry form fields @smoke @reg", async () => {
+    await test.step("Verify Select Project dropdown shows available projects", async () => {
+      await myTimesheets.verifyProjectDropdownHasAvailableProjects();
+    });
+
+    await test.step("Select first available project", async () => {
+      await myTimesheets.selectFirstAvailableProject();
+    });
+
+    await test.step("Select Meeting category", async () => {
+      await myTimesheets.selectCategory("Meeting");
+      await myTimesheets.verifyDropdownSelectedValue("category", "Meeting");
+    });
+
+    await test.step("Enter task description", async () => {
+      await myTimesheets.fillTaskDescription("testing");
+      await myTimesheets.verifyTaskDescription("testing");
+    });
+
+    await test.step("Enter hours worked", async () => {
+      await myTimesheets.fillHours("8");
+      await myTimesheets.verifyHours("8");
+    });
+
+    await test.step("Select minutes", async () => {
+      await myTimesheets.selectMinutes("30");
+      await myTimesheets.verifyDropdownSelectedValue("minutes", "30");
+    });
+
+    await test.step("Select In Progress status", async () => {
+      await myTimesheets.selectStatus("In Progress");
+      await myTimesheets.verifyDropdownSelectedValue("status", "In Progress");
+    });
+  });
 });

--- a/tests/TimesheetManagement/myTimesheet.spec.ts
+++ b/tests/TimesheetManagement/myTimesheet.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+import { Dashboard } from "../../pages/Dashboard";
+import { LoginPage } from "../../pages/LoginPage";
+import { MyTimesheets } from "../../pages/MyTimesheets";
+import testData from "../../testData/testData.json";
+
+let dashboard: Dashboard;
+let myTimesheets: MyTimesheets;
+
+test.describe("My Timesheets page", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    const loginPage = new LoginPage(page);
+    await loginPage.validLogin(
+      testData.SuperUser.UserEmail,
+      testData.SuperUser.UserPassword
+    );
+
+    dashboard = new Dashboard(page);
+    myTimesheets = new MyTimesheets(page);
+
+    console.log(">> Starting test case : " + testInfo.title);
+  });
+
+  test.beforeEach(async () => {
+    await test.step("Navigate to Dashboard", async () => {
+      await dashboard.waitForDashboardToLoad();
+    });
+
+    await test.step("Open My Timesheets", async () => {
+      await dashboard.clickSubmitTimesheets();
+      await myTimesheets.waitForMyTimesheetsPage();
+    });
+  });
+
+  test("HRMIS_MTS_01, HRMIS_MTS_02, HRMIS_MTS_03, Verify user can navigate to My Timesheets from Dashboard @smoke @reg", async () => {
+    await myTimesheets.waitForMyTimesheetsPage();
+  });
+
+  test("HRMIS_MTS_04, Verify current date appears on Daily Time Entry section @smoke @reg", async () => {
+    await myTimesheets.verifyDailyTimeEntryDate();
+  });
+
+  test("HRMIS_MTS_05, Verify user can navigate to previous day from Daily Time Entry section @smoke @reg", async () => {
+    const currentDayText = await myTimesheets.getDailyTimeEntryText();
+
+    await myTimesheets.clickPreviousDay();
+
+    await expect
+      .poll(() => myTimesheets.getDailyTimeEntryText())
+      .not.toBe(currentDayText);
+  });
+
+  test("HRMIS_MTS_06, Verify user can navigate to current day by clicking right arrow on Daily Time Entry section @smoke @reg", async () => {
+    const currentDayText = await myTimesheets.getDailyTimeEntryText();
+
+    await myTimesheets.clickPreviousDay();
+    await expect
+      .poll(() => myTimesheets.getDailyTimeEntryText())
+      .not.toBe(currentDayText);
+
+    await myTimesheets.clickNextDay();
+    await expect.poll(() => myTimesheets.getDailyTimeEntryText()).toBe(currentDayText);
+    await myTimesheets.verifyDailyTimeEntryDate();
+  });
+});


### PR DESCRIPTION
This PR adds initial automation coverage for the My Timesheets page.

The new tests cover navigating from the Dashboard to the My Timesheets page and validating the Daily Time Entry section. It verifies that the current date is displayed in the expected format, and that users can move to the previous day and return back to the current day using the left and right arrow controls.
The changes also introduce a dedicated My Timesheets page object so future timesheet-related tests can reuse the same locators and actions cleanly.